### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - networkx
   - matplotlib
   - pyproj
-  - shapely
+  - shapely==1.7.1
   - fiona
   - rivgraph
   - fastdtw


### PR DESCRIPTION
pin shapely?

Looks like pinning shapely to its previous version fixes the broken tests. Somehow despite a quick turnaround from PR to merge (<24 hours) there managed to be a breaking update to a dependency.

Will merge if this passes all tests run on the PR.