### PR TITLE
fix(docs): fix the broken png image reference in Colville demo

### DIFF
--- a/docs/source/examples/delta_example/delta_example.rst
+++ b/docs/source/examples/delta_example/delta_example.rst
@@ -412,7 +412,7 @@ for inspection in a GIS:
 
 Pulling this into QGIS and applying a similar color ramp, we see
 
-.. figure:: images/colville_link_directions.PNG
+.. figure:: images/colville_link_directions.png
    :alt: colville_link_directions.PNG
 
    colville_link_directions.PNG

--- a/docs/source/test/examples/delta_example/delta_example.html
+++ b/docs/source/test/examples/delta_example/delta_example.html
@@ -382,7 +382,7 @@ for inspection in a GIS:</p>
 <pre class="literal-block">Geotiff written to dataColville_DeltaResultsColville_link_directions.tif.</pre>
 <p>Pulling this into QGIS and applying a similar color ramp, we see</p>
 <div class="figure align-default" id="id5">
-<img alt="colville_link_directions.PNG" src="../../_images/colville_link_directions.PNG" />
+<img alt="colville_link_directions.png" src="../../_images/colville_link_directions.png" />
 <p class="caption"><span class="caption-text">colville_link_directions.PNG</span><a class="headerlink" href="#id5" title="Permalink to this image"></a></p>
 </div>
 <p>The pixel values along each link have been rescaled from 0 (upstream) to


### PR DESCRIPTION
Hi.
The link is updated in accordance with the links used for other images and in accordance with the images found at docs/source/examples/delta_example/images.
Currently the image is broke as seem on the [demo page](https://veinsoftheearth.github.io/RivGraph/examples/delta_example/delta_example.html).